### PR TITLE
Add Supabase integration for AIESEC form submission

### DIFF
--- a/src/pages/api/forms/aiesec.ts
+++ b/src/pages/api/forms/aiesec.ts
@@ -1,21 +1,10 @@
 import { NextApiRequest, NextApiResponse } from "next";
-import { connect, Int, VarChar, config as SqlConfig, ConnectionPool } from "mssql";
 import { verifyJwtFromCookies } from "../cookieManagement";
+import { dbQuery } from "../db";
 
-const config: SqlConfig = {
-  user: process.env.DB_USER as string,
-  password: process.env.DB_PASS as string,
-  database: process.env.DB_NAME as string,
-  server: process.env.DB_SERVER as string,
-  port: parseInt(process.env.DB_PORT ?? "1433", 10),
-  options: {
-    encrypt: true,
-    trustServerCertificate: false,
-  },
-};
+
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
-  let pool: ConnectionPool | null = null;
 
   try {
     if (req.method !== "POST") {
@@ -27,74 +16,47 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       });
     }
 
+    // 1) Email desde JWT cookie
     const email = verifyJwtFromCookies(req, res);
+    if (!email || typeof email !== "string") {
+      return res.status(401).json({
+        notification: { type: "error", message: "Sesión inválida o expirada." },
+      });
+    }
+    
+    // 2) Datos del form
     const group_id = 13;
-    const phone = req.body.phone;
+    const department = String(req.body?.department ?? "").trim();
 
-    const phoneRegex = /^3\d{9}$/;
-
-    if (!phoneRegex.test(phone)) {
+    // 3) Insert en Supabase/Postgres
+    const result = await dbQuery<{ id_grupo: number }>(
+      `INSERT INTO aiesec (id_grupo, correo, departamento)
+       VALUES ($1, $2, $3)
+       ON CONFLICT (id_grupo, correo) DO NOTHING
+       RETURNING id_grupo`,
+      [group_id, email.toLowerCase().trim(), department]
+    );
+      
+    // Respuesta en caso de éxito
+    if (result.rows.length === 0) {
       return res.status(400).json({
         notification: {
           type: "error",
-          message: "Número de teléfono inválido. Debe ser un número celular colombiano de 10 dígitos que comience por 3.",
+          message: "Ya estás registrado en este grupo.",
         },
       });
     }
 
-
-
-    pool = await connect(config);
-
-    try {
-      // Intentar insertar en la base de datos
-      await pool.request()
-        .input("group_id", Int, group_id)
-        .input("email", VarChar, email)
-        .input("phone", VarChar, phone)
-        .query(`
-          INSERT INTO aiesec (id_grupo, correo, telefono)
-          VALUES (@group_id, @email, @phone)
-        `);
-
-      // Respuesta en caso de éxito
-      return res.status(200).json({
+    return res.status(200).json({
         notification: {
           type: "success",
           message: "Formulario enviado con éxito.",
         },
       });
-    } catch (error: any) {
-      // Manejo de error de clave duplicada
-      if (error.number === 2627) {
-        return res.status(400).json({
-          notification: {
-            type: "error",
-            message: "Ya estás registrado en este grupo.",
-          },
-        });
-      }
-
-      // Otros errores
-      console.error("Error al insertar en la base de datos:", error);
+  } catch (error) {
+      console.error("Error en /api/forms/aiesec:", error);
       return res.status(500).json({
-        notification: {
-          type: "error",
-          message: "Error al guardar los datos. Por favor, inténtalo de nuevo más tarde.",
-        },
+        notification: { type: "error", message: "Error interno del servidor." },
       });
     }
-  } catch (err) {
-    console.error("Error general en el servidor:", err);
-    return res.status(500).json({
-      notification: {
-        type: "error",
-        message: "Error interno del servidor.",
-      },
-    });
-  } finally {
-    if (pool) {
-      pool.close();
-    }
-  }
 }


### PR DESCRIPTION
## Summary

This pull request implements the backend integration for the new AIESEC form, connecting it to Supabase (PostgreSQL) and enabling authenticated users to register their department selection.

## Key changes

- Added a new API endpoint: `/api/forms/aiesec`.
- Integrated Supabase/PostgreSQL using the centralized `db.ts` connection layer.
- The endpoint:
  - Extracts the authenticated user's email from the JWT cookie.
  - Stores the selected AIESEC department linked to the user.
  - Prevents duplicate registrations using a unique constraint.
- Updated logic to match the new AIESEC form structure (department-based submission).
- Improved validation and error handling for the form flow.

## Why this change

This enables persistent storage of AIESEC form submissions, ensures that each user can only register once per group, and integrates the new form into the existing authenticated user flow.

## Notes for reviewers

- This PR only affects the AIESEC form flow.
- It assumes the existence of a unique constraint on `(id_grupo, correo)` in the `aiesec` table.
- Please review the new endpoint logic and database interaction.

